### PR TITLE
Debug shell script in new commit

### DIFF
--- a/router_pi_secure.sh
+++ b/router_pi_secure.sh
@@ -525,7 +525,7 @@ start_router() {
     require openssl
     
     # Auto-detect interfaces if not provided
-    if [[ -z "${WAN_IFACE}" || "${WAN_IFACE}" == "$(ip route 2>/dev/null | awk '/default/ {print $5; exit}') " ]]; then
+    if [[ -z "${WAN_IFACE}" ]]; then
         WAN_IFACE=$(detect_wan_interface)
         log "Detected WAN interface: ${WAN_IFACE}"
     fi
@@ -707,8 +707,8 @@ status_router() {
     # Security status
     echo
     echo "🔒 Security Status:"
-    echo "  Firewall: $(iptables -L INPUT | grep -q "DROP" && echo "ACTIVE" || echo "INACTIVE")"
-    echo "  DNS Security: $(systemctl is-active dnsmasq 2>/dev/null || echo "inactive")"
+    echo "  Firewall: $(iptables -L INPUT | grep -q 'DROP' && echo ACTIVE || echo INACTIVE)"
+    echo "  DNS Security: $(systemctl is-active dnsmasq 2>/dev/null || echo inactive)"
     
     echo
 }


### PR DESCRIPTION
Fix shell script errors by correcting nested quoting in `status_router` and simplifying WAN interface detection.

The previous commit introduced nested double quotes in command substitutions within `status_router`, causing shell parsing errors. Additionally, the WAN detection logic in `start_router` was overly complex and prone to issues due to comparing `WAN_IFACE` with a default route string that included a trailing space.

---
<a href="https://cursor.com/background-agent?bcId=bc-10febb6b-8cdf-43fb-873f-38a805cc1997">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10febb6b-8cdf-43fb-873f-38a805cc1997">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

